### PR TITLE
Add some event styling.

### DIFF
--- a/app/css/sections/conversation.styl
+++ b/app/css/sections/conversation.styl
@@ -132,3 +132,37 @@
 
   .error & { display: block; }
 }
+
+.conversation-event {
+  margin: 15px 0 15px 9px;
+}
+
+.discussion-item-icon {
+  float: left;
+  width: 30px;
+  height: 30px;
+  margin-top: -7px;
+  margin-right: 7px;
+  line-height: 30px;
+  color: #666666;
+  text-align: center;
+  background-color: #f3f3f3;
+  border-radius: 50%;
+}
+
+.conversation-event .octicon-issue-reopened {
+  color: #fff;
+  background-color: issue-opened-color;
+}
+
+.conversation-event .octicon-git-merge {
+  padding-left: 2px;
+  color: #fff;
+  background-color: git-merge-color;
+}
+
+.conversation-event .octicon-circle-slash {
+  color: #fff;
+  background-color: issue-closed-color;
+}
+

--- a/app/css/variables.styl
+++ b/app/css/variables.styl
@@ -12,6 +12,8 @@ brand-yellow = #E4D591; // used on private lock on .com
 
 pull-request-color = #9e157c;
 issue-opened-color = #489d00;
+issue-closed-color = #bd2c00;
 git-commit-color = #156f9e;
+git-merge-color = #6e5494;
 
 header-color = #3488B6;


### PR DESCRIPTION
Adds basic styling to events to imitate the styles of github.com.

![screen shot 2014-04-13 at 4 58 12 pm](https://cloud.githubusercontent.com/assets/185926/2689019/599cd2e8-c2dd-11e3-9bc1-9957abd2dfa3.png)

I haven't been particularly thorough, so I may have missed event types.

I also tried to merge master in to bring the branch up to date, but there were a bunch of conflicts, so I didn't mess with that :shit: in the interests of keeping this simple.
