### PR TITLE
"o" shortcut for unknown notifications

### DIFF
--- a/app/js/views/notification_details.coffee
+++ b/app/js/views/notification_details.coffee
@@ -41,10 +41,7 @@ class App.Views.NotificationDetailsView extends Backbone.View
 
   # Go to the page on GitHub for this notification
   open: (e) ->
-    if unread = @model.subject.comments.detect((comment) -> comment.isUnread())
-      window.open unread.get('html_url'), '_blank'
-    else
-      window.open @model.subject.get('html_url'), '_blank'
+    window.open @subject.url(), '_blank'
 
   # Focus the reply textarea
   reply:(e) ->

--- a/app/js/views/subject.coffee
+++ b/app/js/views/subject.coffee
@@ -44,3 +44,9 @@ class App.Views.Subject extends Backbone.View
 
   show: ->
     @timelineView.bindKeyboardEvents()
+
+  url: ->
+    if unread = @model.comments.detect((comment) -> comment.isUnread())
+      unread.get('html_url')
+    else
+      @model.get('html_url')

--- a/app/js/views/subject/unknown.coffee
+++ b/app/js/views/subject/unknown.coffee
@@ -3,9 +3,11 @@ class App.Views.Subject.Unknown extends Backbone.View
   className: 'subject content'
 
   initialize: ->
-    url = @model.notification.get('repository').html_url + '/notifications'
-    @$el.html @template(url: url)
+    @$el.html @template(url: @url())
+
+  url: ->
+    @model.get('html_url') || @model.notification.get('repository').html_url + '/notifications'
 
   show: ->
-    
+
   hide: ->


### PR DESCRIPTION
This makes the "o" keyboard shortcut work on unsupported notifications.

/cc #108 @michaeltwofish
