### PR TITLE
Show merged state of PR

### DIFF
--- a/app/css/sections/conversation.styl
+++ b/app/css/sections/conversation.styl
@@ -179,8 +179,9 @@
   margin-right: 8px;
   line-height: 20px;
 
-  &.open { background-color: #6cc644; }
-  &.closed { background-color: #bd2c00; }
+  &.open { background-color: issue-opened-color; }
+  &.closed { background-color: issue-closed-color; }
+  &.merged { background-color: git-merge-color; }
   .octicon { color: #fff; }
 }
 

--- a/app/js/models/subject/pull_request.coffee
+++ b/app/js/models/subject/pull_request.coffee
@@ -7,3 +7,8 @@ class App.Models.Subject.PullRequest extends App.Models.Subject
 
     @on 'change', ->
       @events.url = @get('issue_url') + '/events'
+
+  toJSON: ->
+    attrs = super
+    attrs.state = 'merged' if attrs.merged
+    attrs


### PR DESCRIPTION
The GitHub API just has `closed` and `open` as states, with a separate `merged` boolean on PRs.

Closes #112 

![github_notifications](https://cloud.githubusercontent.com/assets/173/3863294/d3149320-1f46-11e4-8672-3a298e74134a.png)
