### PR TITLE
always try to scroll when selecting a notification

### DIFF
--- a/app/js/views/notification.coffee
+++ b/app/js/views/notification.coffee
@@ -21,7 +21,4 @@ class App.Views.Notification extends Backbone.View
     @$el.removeClass('selected')
 
   selected: ->
-    @$el.addClass('selected')
-
-    # Only scroll if is out of view. Otherwise it triggers an unnecessary scroll event
-    @$el.scrollIntoView(100) if @$el.isOutOfView()
+    @$el.addClass('selected').scrollIntoView(100)


### PR DESCRIPTION
`$.fn.isOutOfView` does not work with a scrollable div. I'm not really interested in fixing that right now, so we'll just always attempt to scroll. This fires unnecessary scroll events, which will cause the notification list to poll at times when it doesn't need to, but we can live that for now.

Closes #126 
