### PR TITLE
Add direct mention filter

### DIFF
--- a/app/js/app.coffee
+++ b/app/js/app.coffee
@@ -38,7 +38,8 @@ class @App
     @filters = new App.Collections.Filters([
       {id: 'everything', name: 'Everything', data: {}, octicon: 'inbox'},
       {id: 'participating', name: 'Participating', data: {participating: true}, reasons: ['mention', 'author', 'comment', 'state_change', 'assign'], octicon: 'comment-discussion'}
-      {id: 'mentioned', name: 'Mentioned', data: {participating: true}, reasons: ['team_mention'], octicon: 'jersey'},
+      {id: 'mentioned', name: 'Team Mentions', data: {participating: true}, reasons: ['team_mention'], octicon: 'jersey'},
+      {id: 'direct', name: 'Direct Mentions', data: {participating: true}, reasons: ['mention', 'author'], octicon: 'mention'},
     ])
 
     @repositories = new App.Collections.Repositories()

--- a/app/js/views/shortcuts.coffee
+++ b/app/js/views/shortcuts.coffee
@@ -18,9 +18,13 @@ class App.Views.Shortcuts extends Backbone.View
       key: 'g p'
       action: -> Backbone.history.navigate 'participating', trigger: true
 
-    'Go to Mentioned':
-      key: 'g m'
+    'Go to Team Mentions':
+      key: 'g t'
       action: -> Backbone.history.navigate 'mentioned', trigger: true
+
+    'Go to Direct Mentions':
+      key: 'g d'
+      action: -> Backbone.history.navigate 'direct', trigger: true
 
     'Open help for keyboard shortcuts':
       key: '?'


### PR DESCRIPTION
For a very long time I’ve wanted to be able to filter by just those notifications that mention me directly. I’ve mostly used email notifications and dabbled with google scripts hacks to achieve this until now, but forgot that this project was a thing, and it seems pretty simple to add it in. Here’s what it looks like:

![2014-11-06 at 13 18](https://cloud.githubusercontent.com/assets/296432/4936321/d6c5e2a0-65b7-11e4-9137-e8097a7ec6a5.png)

I realise this may not be what everyone wants, so I’m totally cool if you don’t want to merge this. Happy to run my own version elsewhere if needed, but if I have a burning desire for this, I figured other people might too :grin: 

/cc @bkeepers 
