### PR TITLE
WIP: customizable filters

### DIFF
--- a/app/css/app.styl
+++ b/app/css/app.styl
@@ -9,6 +9,7 @@
 @import "components/segmented-control";
 @import "components/modal";
 @import "components/tabnav";
+@import "components/selector";
 
 @import "sections/sidebar";
 @import "sections/lists";

--- a/app/css/components/forms.styl
+++ b/app/css/components/forms.styl
@@ -23,6 +23,11 @@ textarea {
     border-color: #51a7e8;
     box-shadow: inset 0 1px 2px rgba(0,0,0,.075), 0 0 3px rgba(81,167,232,.5);
   }
+
+  &.invalid {
+    border-color: brand-red;
+  }
+
 }
 
 // Custom styling for HTML5 validation bubbles (WebKit only)

--- a/app/css/components/modal.styl
+++ b/app/css/components/modal.styl
@@ -9,6 +9,7 @@
 }
 
 .modal {
+  z-index: 101;
   width: 450px;
   margin: 10% auto;
   background: #fff;

--- a/app/css/components/modal.styl
+++ b/app/css/components/modal.styl
@@ -1,4 +1,4 @@
-.overlay {
+.overlay, .modal {
   position: absolute;
   left: 0;
   right: 0;
@@ -8,10 +8,12 @@
   z-index: 100;
 }
 
-.modal {
+.dialog {
   z-index: 101;
-  width: 450px;
+  width: 416px;
   margin: 10% auto;
+  max-height: 80%;
+  overflow: auto;
   background: #fff;
   border-radius: 3px;
   padding: 20px;

--- a/app/css/components/selector.styl
+++ b/app/css/components/selector.styl
@@ -1,0 +1,34 @@
+// Create a
+//
+//   <div class="selector">
+//     <input id="option-1" type="radio">
+//     <label for="option-1">Item</label>
+//   </div>
+.selector {
+  height: 6.5em;
+  line-height: 36px;
+  overflow: auto;
+
+  label {
+    margin: 0 5px 5px 0;
+    border: 1px solid #eee;
+    border-radius: 3px;
+    width: 36px;
+    height: 36px;
+    text-align: center;
+    display: block;
+    float: left;
+  }
+
+  input:checked + label {
+    background-color: brand-blue;
+    color: #fff;
+    border-color: transparent;
+  }
+
+  input[type=checkbox], input[type=radio] {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+}

--- a/app/css/components/selector.styl
+++ b/app/css/components/selector.styl
@@ -5,19 +5,49 @@
 //     <label for="option-1">Item</label>
 //   </div>
 .selector {
-  height: 6.5em;
-  line-height: 36px;
-  overflow: auto;
+  &, li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    clearfix();
+  }
 
   label {
-    margin: 0 5px 5px 0;
+    margin: 0 4px 4px 0;
     border: 1px solid #eee;
     border-radius: 3px;
-    width: 36px;
-    height: 36px;
-    text-align: center;
     display: block;
-    float: left;
+
+    .octicon {
+      display: inline-block;
+      width: 32px;
+      height: 32px;
+      text-align: center;
+      line-height: 34px;
+    }
+  }
+
+  &.row {
+    height: 48px;
+
+    overflow-x: scroll;
+    overflow-y: hidden;
+    white-space: nowrap;
+
+    li {
+      display: inline-block;
+    }
+  }
+
+  &.colums {
+    li {
+      float: left;
+      width: 50%;
+
+      &:nth-child(2n) label {
+        margin-right: 0;
+      }
+    }
   }
 
   input:checked + label {

--- a/app/js/app.coffee
+++ b/app/js/app.coffee
@@ -55,7 +55,10 @@ class @App
     new App.Routers.Notifications(@vent)
     new App.Controllers.Notification(@vent)
 
-    new App.Views.Shortcuts(vent: @vent, repositories: @repositories)
+    new App.Views.Shortcuts
+      vent: @vent
+      repositories: @repositories
+      filters: @filters
 
     new App.Routers.Misc
 

--- a/app/js/app.coffee
+++ b/app/js/app.coffee
@@ -64,7 +64,7 @@ class @App
 
     Backbone.history.start() unless Backbone.History.started
 
-    Backbone.history.navigate 'everything', trigger: true
+    app.filters.first().select()
 
   # Notifictions do not get marked as read when in development mode.
   isDevelopment: ->

--- a/app/js/controllers/filters.coffee
+++ b/app/js/controllers/filters.coffee
@@ -35,6 +35,8 @@ class App.Controllers.Filters
     @listenTo @vent, 'filter:selected repository:selected', @show
     @listenTo @vent, 'filter:unselected repository:unselected', @hide
 
+    @listenTo @vent, 'filter:new', @new
+
     @repositories.fetch()
     @repositories.startPolling()
 
@@ -61,3 +63,10 @@ class App.Controllers.Filters
 
   hide: (model) ->
     @cache.get(model.cid)?.hide()
+
+  new: ->
+    view = new App.Views.FiltersCreate
+      collection: @filters
+      model: new App.Models.Filter()
+
+    $(document.body).append view.render().el

--- a/app/js/controllers/filters.coffee
+++ b/app/js/controllers/filters.coffee
@@ -29,6 +29,8 @@ class App.Controllers.Filters
     @listenTo @repositories, 'unselected', (model) =>
       @vent.trigger 'repository:unselected', model
 
+    @listenTo @filters, 'add', @selectFilter
+
     @listenTo @vent, 'filter:select', @selectFilter
     @listenTo @vent, 'repository:select', @selectRepository
 

--- a/app/js/models/filter.coffee
+++ b/app/js/models/filter.coffee
@@ -1,10 +1,35 @@
 class App.Models.Filter extends Backbone.Model
+  defaults:
+    octicon: 'inbox'
+    reasons: [
+      'subscribed'
+      'manual'
+      'author'
+      'comment'
+      'mention'
+      'team_mention'
+      'state_change'
+      'assign'
+    ]
 
   initialize: ->
+    @generateId()
+    @on 'change:name', @generateId
     @notifications = new App.Collections.Notifications([], filter: @reasonFilter, data: @get('data'))
+
+  generateId: (name) ->
+    @set 'id', name.toLowerCase() if name = @get('name')
 
   reasonFilter: (model) =>
     !@get('reasons') || model.get('reason') in @get('reasons')
 
   read: ->
     # noop
+
+  validate: ->
+    errors = []
+
+    errors.push('name') unless @get('name')
+    errors.push('octicon') unless @get('octicon')
+
+    errors unless errors.length == 0

--- a/app/js/routes/filters.coffee
+++ b/app/js/routes/filters.coffee
@@ -1,6 +1,6 @@
 class App.Routers.Filters extends Backbone.Router
   routes:
-    'r/:id': 'repository'
+    'r/:id': (id) -> @vent.trigger 'repository:select', id
 
   initialize: (options) ->
     @filters = options.filters
@@ -17,6 +17,3 @@ class App.Routers.Filters extends Backbone.Router
 
   filter: (id) ->
     @vent.trigger 'filter:select', id
-
-  repository: (full_name) ->
-    @vent.trigger 'repository:select', full_name

--- a/app/js/routes/filters.coffee
+++ b/app/js/routes/filters.coffee
@@ -1,19 +1,13 @@
 class App.Routers.Filters extends Backbone.Router
   routes:
+    'filter/:id': (id) -> @vent.trigger 'filter:select', id
     'r/:id': (id) -> @vent.trigger 'repository:select', id
 
   initialize: (options) ->
-    @filters = options.filters
     @vent = options.vent
 
-    @route(new RegExp("^(#{@filters.pluck('id').join('|')})$"), 'filter')
-    @route(/^([\w\.\-]+\/[\w\.\-]+)$/, 'repository')
-
     @listenTo @vent, 'filter:selected', (model) =>
-      @navigate "##{model.id}" if model
+      @navigate "#filter/#{model.id}" if model
 
     @listenTo @vent, 'repository:selected', (model) =>
-      @navigate "#/#{model.get('full_name')}" if model
-
-  filter: (id) ->
-    @vent.trigger 'filter:select', id
+      @navigate "#r/#{model.get('full_name')}" if model

--- a/app/js/routes/filters.coffee
+++ b/app/js/routes/filters.coffee
@@ -2,7 +2,8 @@ class App.Routers.Filters extends Backbone.Router
   routes:
     'filter/new': -> @vent.trigger 'filter:new'
     'filter/:id': (id) -> @vent.trigger 'filter:select', id
-    'r/:id': (id) -> @vent.trigger 'repository:select', id
+    'r/:owner/:login': (owner, login) ->
+      @vent.trigger 'repository:select', "#{owner}/#{login}"
 
   initialize: (options) ->
     @vent = options.vent

--- a/app/js/routes/filters.coffee
+++ b/app/js/routes/filters.coffee
@@ -1,5 +1,6 @@
 class App.Routers.Filters extends Backbone.Router
   routes:
+    'filter/new': -> @vent.trigger 'filter:new'
     'filter/:id': (id) -> @vent.trigger 'filter:select', id
     'r/:id': (id) -> @vent.trigger 'repository:select', id
 

--- a/app/js/views/feedback.coffee
+++ b/app/js/views/feedback.coffee
@@ -1,6 +1,7 @@
 class App.Views.Feedback extends Backbone.View
   template: JST['app/templates/feedback.us']
   confirmTemplate: JST['app/templates/feedback_confirm.us']
+  className: 'modal'
 
   events:
     'submit form': 'submit'

--- a/app/js/views/filter.coffee
+++ b/app/js/views/filter.coffee
@@ -1,5 +1,5 @@
 class App.Views.Filter extends Backbone.View
-  template: _.template('<a href="#<%- id %>"><span class="octicon octicon-<%- octicon %>"></span> <%- name %></a>')
+  template: _.template('<a href="#filter/<%- id %>"><span class="octicon octicon-<%- octicon %>"></span> <%- name %></a>')
   className: 'list'
   tagName: 'li'
 

--- a/app/js/views/filter.coffee
+++ b/app/js/views/filter.coffee
@@ -1,5 +1,6 @@
 class App.Views.Filter extends Backbone.View
-  template: _.template('<a href="#filter/<%- id %>"><span class="octicon octicon-<%- octicon %>"></span> <%- name %></a>')
+  template: JST['app/templates/filters/list_item.us']
+
   className: 'list'
   tagName: 'li'
 

--- a/app/js/views/filter.coffee
+++ b/app/js/views/filter.coffee
@@ -6,6 +6,8 @@ class App.Views.Filter extends Backbone.View
   initialize: (options) ->
     @listenTo @model, 'unselected', @unselected
     @listenTo @model, 'selected', @selected
+    @listenTo @model, 'changed', @render
+
 
   render: =>
     @$el.html @template(@model.toJSON())

--- a/app/js/views/filter/create.coffee
+++ b/app/js/views/filter/create.coffee
@@ -4,20 +4,35 @@ class App.Views.FiltersCreate extends Backbone.View
   className: 'modal'
 
   octicons: '
-    alert beer book briefcase broadcast browser bug calendar check circuit-board clock cloud-download code comment-discussion dashboard
-    database device-camera device-camera-video device-desktop device-mobile diff diff-added diff-ignored diff-modified diff-removed diff-renamed ellipsis eye file-binary file-code file-directory file-media file-pdf file-submodule file-symlink-directory file-symlink-file file-text file-zip flame fold gear gift gist gist-secret git-branch git-commit git-compare git-merge git-pull-request globe graph heart history home horizontal-rule hourglass hubot inbox info issue-closed issue-opened issue-reopened jersey jump-down jump-left jump-right jump-up key keyboard law light-bulb link link-external list-ordered list-unordered location lock logo-github mail mail-read mail-reply mark-github markdown megaphone mention microscope milestone mirror mortar-board move-down move-left move-right move-up mute no-newline octoface organization package paintcan pencil person pin playback-fast-forward playback-pause playback-play playback-rewind plug plus podium primitive-dot primitive-square pulse puzzle question quote radio-tower repo repo-clone repo-force-push repo-forked repo-pull repo-push rocket rss ruby screen-full screen-normal search server settings sign-in sign-out split squirrel star steps stop sync tag telescope terminal three-bars tools trashcan triangle-down triangle-left triangle-right triangle-up unfold unmute versions x zap
+    alert beer book briefcase broadcast browser bug calendar check circuit-board clock cloud-download code comment-discussion dashboard database device-camera device-camera-video device-desktop device-mobile diff diff-added diff-ignored diff-modified diff-removed diff-renamed ellipsis eye file-binary file-code file-directory file-media file-pdf file-submodule file-symlink-directory file-symlink-file file-text file-zip flame fold gear gift gist gist-secret git-branch git-commit git-compare git-merge git-pull-request globe graph heart history home horizontal-rule hourglass hubot inbox info issue-closed issue-opened issue-reopened jersey jump-down jump-left jump-right jump-up key keyboard law light-bulb link link-external list-ordered list-unordered location lock mail mail-read mail-reply mark-github markdown megaphone mention microscope milestone mirror mortar-board mute octoface organization package paintcan pencil person pin plug podium pulse puzzle question quote radio-tower repo repo-clone repo-force-push repo-forked repo-pull repo-push rocket rss ruby search server settings sign-in sign-out split squirrel star steps stop sync tag telescope terminal three-bars tools trashcan unfold unmute versions x zap
   '.trim().split(/\s+/)
 
   # https://developer.github.com/v3/activity/notifications/#notification-reasons
   reasons:
-    'subscribed':	  'you are watching the repository'
-    'manual':	      'you specifically decided to watch the item (via an Issue or Pull Request)'
-    'author':	      'you created the item'
-    'comment':	    'you commented on the item'
-    'mention':	    'you were specifically @mentioned in the content'
-    'team_mention':	'you were on a team that was mentioned (like @org/team)'
-    'state_change':	'you changed the item state (like closing an Issue or merging a Pull Request)'
-    'assign':	      'you were assigned to the Issue'
+    subscribed:
+      octicon:      'repo'
+      description:  'watching the repository'
+    manual:
+      octicon:      'eye'
+      description:  'you manually subscribed'
+    author:
+      octicon:      'pencil'
+      description:  'created by you'
+    comment:
+      octicon:      'comment'
+      description:  'you commented'
+    mention:
+      octicon:      'mention'
+      description:  'you were mentioned'
+    team_mention:
+      octicon:      'jersey'
+      description:  'a team was mentioned'
+    state_change:
+      octicon:      'issue-closed'
+      description:  'you changed the state'
+    assign:
+      octicon:      'checklist'
+      description:  'assigned to you'
 
   events:
     'submit form': 'save'

--- a/app/js/views/filter/create.coffee
+++ b/app/js/views/filter/create.coffee
@@ -1,0 +1,43 @@
+# FIXME: move to App.Views.Filters.Create
+class App.Views.FiltersCreate extends Backbone.View
+  template: JST['app/templates/filters/create.us']
+
+  octicons: '
+    alert beer book briefcase broadcast browser bug calendar check circuit-board clock cloud-download code comment-discussion dashboard
+    database device-camera device-camera-video device-desktop device-mobile diff diff-added diff-ignored diff-modified diff-removed diff-renamed ellipsis eye file-binary file-code file-directory file-media file-pdf file-submodule file-symlink-directory file-symlink-file file-text file-zip flame fold gear gift gist gist-secret git-branch git-commit git-compare git-merge git-pull-request globe graph heart history home horizontal-rule hourglass hubot inbox info issue-closed issue-opened issue-reopened jersey jump-down jump-left jump-right jump-up key keyboard law light-bulb link link-external list-ordered list-unordered location lock logo-github mail mail-read mail-reply mark-github markdown megaphone mention microscope milestone mirror mortar-board move-down move-left move-right move-up mute no-newline octoface organization package paintcan pencil person pin playback-fast-forward playback-pause playback-play playback-rewind plug plus podium primitive-dot primitive-square pulse puzzle question quote radio-tower repo repo-clone repo-force-push repo-forked repo-pull repo-push rocket rss ruby screen-full screen-normal search server settings sign-in sign-out split squirrel star steps stop sync tag telescope terminal three-bars tools trashcan triangle-down triangle-left triangle-right triangle-up unfold unmute versions x zap
+  '.trim().split(/\s+/)
+
+  # https://developer.github.com/v3/activity/notifications/#notification-reasons
+  reasons:
+    'subscribed':	  'you are watching the repository'
+    'manual':	      'you specifically decided to watch the item (via an Issue or Pull Request)'
+    'author':	      'you created the item'
+    'comment':	    'you commented on the item'
+    'mention':	    'you were specifically @mentioned in the content'
+    'team_mention':	'you were on a team that was mentioned (like @org/team)'
+    'state_change':	'you changed the item state (like closing an Issue or merging a Pull Request)'
+    'assign':	      'you were assigned to the Issue'
+
+  events:
+    'submit form': 'save'
+    'click .close,.overlay': 'cancel'
+
+  render: ->
+    @$el.html @template(octicons: @octicons, reasons: @reasons, types: @types)
+    @
+
+  save: (e) ->
+    e.preventDefault()
+
+    @model.set
+      name: @$("input[name=name]").val()
+      octicon: @$("input[name=octicon]:checked").val()
+      reasons: (input.value for input in @$("input[name=reason]:checked").serializeArray())
+
+    @remove()
+    @collection.add @model
+
+  cancel: (e) ->
+    e.preventDefault()
+    window.history.back()
+    @remove()

--- a/app/js/views/filter/create.coffee
+++ b/app/js/views/filter/create.coffee
@@ -1,6 +1,7 @@
 # FIXME: move to App.Views.Filters.Create
 class App.Views.FiltersCreate extends Backbone.View
   template: JST['app/templates/filters/create.us']
+  className: 'modal'
 
   octicons: '
     alert beer book briefcase broadcast browser bug calendar check circuit-board clock cloud-download code comment-discussion dashboard

--- a/app/js/views/filter/create.coffee
+++ b/app/js/views/filter/create.coffee
@@ -22,8 +22,11 @@ class App.Views.FiltersCreate extends Backbone.View
     'submit form': 'save'
     'click .close,.overlay': 'cancel'
 
+  initialize: ->
+    @listenTo @model, "invalid", @invalid
+
   render: ->
-    @$el.html @template(octicons: @octicons, reasons: @reasons, types: @types)
+    @$el.html @template(model: @model.toJSON(), octicons: @octicons, reasons: @reasons, types: @types)
     @
 
   save: (e) ->
@@ -34,8 +37,14 @@ class App.Views.FiltersCreate extends Backbone.View
       octicon: @$("input[name=octicon]:checked").val()
       reasons: (input.value for input in @$("input[name=reason]:checked").serializeArray())
 
-    @remove()
-    @collection.add @model
+    if @model.isValid()
+      @remove()
+      @collection.add @model
+
+  invalid: (_, errors) ->
+    @$(".invalid").removeClass("invalid")
+    @$("input[name=#{field}]").addClass("invalid") for field in errors
+    @$(".invalid:first").focus()
 
   cancel: (e) ->
     e.preventDefault()

--- a/app/js/views/filters.coffee
+++ b/app/js/views/filters.coffee
@@ -2,6 +2,7 @@ class App.Views.Filters extends Backbone.View
   el: '#filters'
 
   initialize: ->
+    @listenTo @collection, 'add', @add
     @addAll()
 
   add: (model) ->

--- a/app/js/views/shortcuts.coffee
+++ b/app/js/views/shortcuts.coffee
@@ -10,18 +10,6 @@ class App.Views.Shortcuts extends Backbone.View
       keys: ['k', 'up']
       action: 'prev'
 
-    'Go to Everything':
-      key: 'g e'
-      action: -> Backbone.history.navigate 'everything', trigger: true
-
-    'Go to Participating':
-      key: 'g p'
-      action: -> Backbone.history.navigate 'participating', trigger: true
-
-    'Go to Mentioned':
-      key: 'g m'
-      action: -> Backbone.history.navigate 'mentioned', trigger: true
-
     'Open help for keyboard shortcuts':
       key: '?'
       action: 'help'
@@ -43,6 +31,11 @@ class App.Views.Shortcuts extends Backbone.View
     'ctrl+`': 'toggleDevelopmentMode'
 
   initialize: (options) ->
+    options.filters.each (filter) =>
+      @shortcuts["Go to #{filter.get("name")}"] =
+        key: "g #{filter.id.substr(0, 1)}"
+        action: -> filter.select()
+
     @setElement document.body # otherwise it won't capture all the shortcuts
 
     @repositories = options.repositories

--- a/app/templates/feedback.us
+++ b/app/templates/feedback.us
@@ -1,14 +1,14 @@
 <div class="overlay">
-  <div class="modal">
-    <a href="#" class="octicon octicon-remove-close close"></a>
-    <form>
-      <h2 class="header">I just want to let you know…</h2>
-      <p><input type="text" class="fullwidth" name="title" placeholder="Subject"></p>
-      <p><textarea name="body" placeholder="Explain what you mean."></textarea></p>
-      <p class="note obscure-links">This will be posted to a public issue on <a target="_blank" href="https://github.com/bkeepers/github-notifications">bkeepers/github-notifications</a>.</p>
-      <div class="form-actions">
-        <button class="button primary">Send Feedback</button>
-      </div>
-    </form>
-  </div>
+</div>
+<div class="dialog">
+  <a href="#" class="octicon octicon-remove-close close"></a>
+  <form>
+    <h2 class="header">I just want to let you know…</h2>
+    <p><input type="text" class="fullwidth" name="title" placeholder="Subject"></p>
+    <p><textarea name="body" placeholder="Explain what you mean."></textarea></p>
+    <p class="note obscure-links">This will be posted to a public issue on <a target="_blank" href="https://github.com/bkeepers/github-notifications">bkeepers/github-notifications</a>.</p>
+    <div class="form-actions">
+      <button class="button primary">Send Feedback</button>
+    </div>
+  </form>
 </div>

--- a/app/templates/feedback_confirm.us
+++ b/app/templates/feedback_confirm.us
@@ -1,12 +1,12 @@
 <div class="overlay">
-  <div class="modal">
-    <a href="#" class="octicon octicon-remove-close close"></a>
-    <form>
-      <h2 class="header">Thanks for your feedback!</h2>
-      <p>
-        Sharing is caring! You can follow the discussion at
-        <a target="_blank" href="<%- html_url %>">bkeepers/github-notifications#<%- number %></a>.
-      </p>
-    </form>
-  </div>
+</div>
+<div class="dialog">
+  <a href="#" class="octicon octicon-remove-close close"></a>
+  <form>
+    <h2 class="header">Thanks for your feedback!</h2>
+    <p>
+      Sharing is caring! You can follow the discussion at
+      <a target="_blank" href="<%- html_url %>">bkeepers/github-notifications#<%- number %></a>.
+    </p>
+  </form>
 </div>

--- a/app/templates/filters/create.us
+++ b/app/templates/filters/create.us
@@ -6,22 +6,25 @@
     <p><input type="text" class="fullwidth" name="name" placeholder="Name"></p>
 
     <h3>Icon</h3>
-    <div class="selector">
+    <ul class="selector row">
       <% _.each(octicons, function(octicon) { %>
-        <input id="octicon-<%= octicon %>" type="radio" name="octicon" value="<%= octicon %>"<%= model.octicon == octicon ? ' checked' : '' %>>
-        <label for="octicon-<%= octicon %>" class="selector-option">
-          <span class="octicon octicon-<%= octicon %>"></span>
-        </label>
+        <li>
+          <input id="octicon-<%= octicon %>" type="radio" name="octicon" value="<%= octicon %>"<%= model.octicon == octicon ? ' checked' : '' %>>
+          <label for="octicon-<%= octicon %>">
+            <span class="octicon octicon-<%= octicon %>"></span>
+          </label>
+        </li>
       <% }); %>
-    </div>
+    </ul>
 
     <h3>Reason</h3>
-    <ul>
-    <% _.each(reasons, function(description, reason) { %>
+    <ul class="selector colums">
+    <% _.each(reasons, function(reason, value) { %>
       <li>
-        <label for="reason-<%- reason %>">
-          <input id="reason-<%- reason %>" type="checkbox" name="reason" value="<%= reason %>"<%= model.reasons.indexOf(reason) >= 0 ? 'checked' : '' %>>
-          <%- description %></label>
+        <input id="reason-<%- value %>" type="checkbox" name="reason" value="<%= value %>"<%= model.reasons.indexOf(value) >= 0 ? 'checked' : '' %>>
+        <label for="reason-<%- value %>">
+          <span class="octicon octicon-<%= reason.octicon %>"></span>
+          <%- reason.description %>
         </label>
       </li>
     <% }); %>

--- a/app/templates/filters/create.us
+++ b/app/templates/filters/create.us
@@ -1,4 +1,4 @@
-<div class="modal">
+<div class="dialog">
   <a href="#" class="octicon octicon-remove-close close"></a>
   <form>
     <h2 class="header">New Filter</h2>

--- a/app/templates/filters/create.us
+++ b/app/templates/filters/create.us
@@ -1,0 +1,35 @@
+<div class="modal">
+  <a href="#" class="octicon octicon-remove-close close"></a>
+  <form>
+    <h2 class="header">New Filter</h2>
+
+    <p><input type="text" class="fullwidth" name="name" placeholder="Name"></p>
+
+    <h3>Icon</h3>
+    <div class="selector">
+      <% _.each(octicons, function(octicon) { %>
+        <input id="octicon-<%= octicon %>" type="radio" name="octicon" value="<%= octicon %>">
+        <label for="octicon-<%= octicon %>" class="selector-option">
+          <span class="octicon octicon-<%= octicon %>"></span>
+        </label>
+      <% }); %>
+    </div>
+
+    <h3>Reason</h3>
+    <ul>
+    <% _.each(reasons, function(description, reason) { %>
+      <li>
+        <label for="reason-<%- reason %>">
+          <input id="reason-<%- reason %>" type="checkbox" name="reason" value="<%= reason %>">
+          <%- description %></label>
+        </label>
+      </li>
+    <% }); %>
+    </ul>
+
+    <div class="form-actions">
+      <button class="button primary">Create Filter</button>
+    </div>
+  </form>
+</div>
+<div class="overlay"></div>

--- a/app/templates/filters/create.us
+++ b/app/templates/filters/create.us
@@ -8,7 +8,7 @@
     <h3>Icon</h3>
     <div class="selector">
       <% _.each(octicons, function(octicon) { %>
-        <input id="octicon-<%= octicon %>" type="radio" name="octicon" value="<%= octicon %>">
+        <input id="octicon-<%= octicon %>" type="radio" name="octicon" value="<%= octicon %>"<%= model.octicon == octicon ? ' checked' : '' %>>
         <label for="octicon-<%= octicon %>" class="selector-option">
           <span class="octicon octicon-<%= octicon %>"></span>
         </label>
@@ -20,7 +20,7 @@
     <% _.each(reasons, function(description, reason) { %>
       <li>
         <label for="reason-<%- reason %>">
-          <input id="reason-<%- reason %>" type="checkbox" name="reason" value="<%= reason %>">
+          <input id="reason-<%- reason %>" type="checkbox" name="reason" value="<%= reason %>"<%= model.reasons.indexOf(reason) >= 0 ? 'checked' : '' %>>
           <%- description %></label>
         </label>
       </li>

--- a/app/templates/filters/list_item.us
+++ b/app/templates/filters/list_item.us
@@ -1,0 +1,4 @@
+<a href="#filter/<%- id %>">
+  <span class="octicon octicon-<%- octicon %>"></span>
+  <%- name %>
+</a>

--- a/app/templates/lists.us
+++ b/app/templates/lists.us
@@ -5,6 +5,8 @@
   <ul id="filters" class="primary">
   </ul>
 
+  <a href="#filter/new">New Filter</a>
+
   <h2 class="title">Repositories</h2>
   <ul id="repositories">
   </ul>

--- a/app/templates/lists.us
+++ b/app/templates/lists.us
@@ -2,10 +2,14 @@
   <h1>GitHub Notifications</h1>
 </header>
 <div class="content">
+  <h2 class="title">
+    Filters
+    <a href="#filter/new"><span class="octicon octicon-plus"></span></a>
+  </h2>
+
   <ul id="filters" class="primary">
   </ul>
 
-  <a href="#filter/new">New Filter</a>
 
   <h2 class="title">Repositories</h2>
   <ul id="repositories">

--- a/app/templates/repository.us
+++ b/app/templates/repository.us
@@ -1,4 +1,4 @@
-<a href="#<%- full_name %>">
+<a href="#r/<%- full_name %>">
   <span class="list-name"><%- full_name %></span>
   <span class="list-unread-count"><%- unread_count %></span>
 </a>

--- a/spec/models/filter_spec.coffee
+++ b/spec/models/filter_spec.coffee
@@ -1,0 +1,26 @@
+describe 'App.Models.Filter', ->
+  describe 'id', ->
+    it 'is set from name', ->
+      model = new App.Models.Filter(name: "FooBar")
+      expect(model.id).toEqual("foobar")
+
+  describe 'validate', ->
+    beforeEach ->
+      @model = new App.Models.Filter
+        name: 'Test'
+        octicon: 'test'
+
+    it 'is valid with all attributes', ->
+      expect(@model.validate()).toBe(undefined)
+
+    it 'is invalid without a name', ->
+      @model.set name: null
+      expect(@model.validate()).toEqual(['name'])
+
+    it 'is invalid with a blank name', ->
+      @model.set name: ""
+      expect(@model.validate()).toEqual(['name'])
+
+    it 'is invalid without an octicon', ->
+      @model.set octicon: null
+      expect(@model.validate()).toEqual(['octicon'])


### PR DESCRIPTION
This is a start of the idea I suggested in https://github.com/bkeepers/github-notifications/pull/130 to allow the filters to be customizable. For now this would only filter by notification reason, but eventually we could add type (Issue, PR, Commit, Release), specific repositories, any repository attribute, or really anything we can imagine.

![github_notifications](https://cloud.githubusercontent.com/assets/173/4948884/b4aaa35e-6616-11e4-8c76-53ac54d72d47.png)
## TODO
- [ ] edit existing filters
- [ ] figure out persistence (local storage or implement a permanent storage API?)
- [ ] cherry pick commits that are not directly related to this feature into master to reduce the size of the diff

/cc @cobyism https://github.com/bkeepers/github-notifications/pull/130
