### PR TITLE
Fix infinite redirect

### DIFF
--- a/app/js/models/oauth.coffee
+++ b/app/js/models/oauth.coffee
@@ -9,7 +9,7 @@
 # Uses the code to complete OAuth and return a JSON object with a token
 class App.Models.OAuth
   location: window.location
-  
+
   url: ->
     app.endpoints.web + "login/oauth/authorize"
 
@@ -35,7 +35,7 @@ class App.Models.OAuth
     @location.assign "#{@url()}?client_id=#{options.client_id}&scope=#{options.scope}"
 
   getCode: ->
-    match = @location.href.match(/\?code=(.*)/)
+    match = @location.search.match(/code=(.*)/)
     match[1] if match
 
   getToken: (code) ->

--- a/spec/models/oauth_spec.coffee
+++ b/spec/models/oauth_spec.coffee
@@ -5,7 +5,7 @@ describe 'App.Models.OAuth', ->
     # Test double for window.location
     @location =
       assign: jasmine.createSpy('assign')
-      href: '/foobar'
+      search: ''
       pathname: '/foobar'
 
     App.Models.OAuth.prototype.location = @location
@@ -24,5 +24,5 @@ describe 'App.Models.OAuth', ->
       expect(@oauth.getCode()).toBe(undefined)
 
     it 'returns code from window.location', ->
-      @location.href = '/foo?code=omg'
+      @location.search = 'foo=bar&code=omg'
       expect(@oauth.getCode()).toEqual('omg')


### PR DESCRIPTION
The redirect from GitHub added extra params, throwing off the lazy regex that is used to extract the param values.

Closes #139 

/cc @mattgraham @garand 