### PR TITLE
Set link and link visited to brand-blue

### DIFF
--- a/app/css/base.styl
+++ b/app/css/base.styl
@@ -9,9 +9,12 @@ body, input, select, textarea, button {
 }
 
 a {
+  color: brand-blue;
   text-decoration: none;
 
-  &:hover: {
+  &:hover:,
+  &:visited {
+    color: brand-blue;
     text-decoration: underline;
   }
 }


### PR DESCRIPTION
I was looking at this project and noticed that the links didn't look quite right.
This PR updates `base.styl` so that the links are now `brand-blue` visited or not.

If this is not the correct place change this style let me know and I can correct it.

Thanks!

### Before
![screen shot 2015-03-16 at 11 24 33](https://cloud.githubusercontent.com/assets/564113/6669401/0f2b30aa-cbcf-11e4-9c51-a26a2352ddc8.png)
![screen shot 2015-03-16 at 11 21 39](https://cloud.githubusercontent.com/assets/564113/6669383/f6a37042-cbce-11e4-90cf-1e3c178124de.png)

### After
![screen shot 2015-03-16 at 11 26 14](https://cloud.githubusercontent.com/assets/564113/6669595/1dce832c-cbd0-11e4-9d43-a0e98274fd33.png)
![screen shot 2015-03-16 at 11 21 52](https://cloud.githubusercontent.com/assets/564113/6669377/f0bcff5e-cbce-11e4-8a1f-658772775a88.png)


