### PR TITLE
Smaller avatars on release notifications

### DIFF
--- a/app/css/sections/conversation.styl
+++ b/app/css/sections/conversation.styl
@@ -85,6 +85,11 @@
   .conversation-summary {
     margin: 0;
     display: inline;
+  
+    .avatar {
+      width: 20px;
+      height: 20px;
+    }
   }
 }
 


### PR DESCRIPTION
Avatars are huge on notifications about releases:
![github notifications](https://cloud.githubusercontent.com/assets/55841/10292200/3174d204-6bae-11e5-862a-41659c7d827f.jpg)
