### PR TITLE
Protips

### DIFF
--- a/app/js/views/lists.coffee
+++ b/app/js/views/lists.coffee
@@ -12,6 +12,8 @@ class App.Views.Lists extends Backbone.View
     @repositories = new App.Views.Repositories(collection: options.repositories)
     @filters = new App.Views.Filters(collection: options.filters)
 
+    new App.Views.Tips()
+
   render: ->
     @$el.html @template()
     app.trigger 'render', @

--- a/app/js/views/tips.coffee
+++ b/app/js/views/tips.coffee
@@ -1,0 +1,21 @@
+# Random tips
+class App.Views.Tips extends Backbone.View
+  el: '#tips'
+  template: JST['app/templates/tips.us']
+
+  tips: [
+    "Hit the <kbd>?</kbd> key for all keyboard awesomeness."
+    "You can reply to comments below the notifications."
+  ]
+
+  # Initialize the view
+  initialize: ->
+    @render()
+
+  render: ->
+    @$el.html @template(tip: @random())
+    app.trigger 'render', @
+    @
+
+  random: ->
+    @tips[Math.floor(Math.random() * @tips.length)]

--- a/app/templates/lists.us
+++ b/app/templates/lists.us
@@ -11,4 +11,6 @@
 
   <a id="send-feedback" href="#feedback">Send Feedback</a>
 
+  <div id="tips"></div>
+
 </div>

--- a/app/templates/tips.us
+++ b/app/templates/tips.us
@@ -1,0 +1,5 @@
+<p>
+  <span class="octicon octicon-light-bulb text-muted"></span>
+  <strong>ProTip!</strong>
+  <%= tip %>
+</p>


### PR DESCRIPTION
It was after reading the source that you've build-in the <kbd>?</kbd> shortcut for a help window. To give other people access to this awesome feature, I added protips just like GitHub has (e.g. below this PR).

![github notifications](https://cloud.githubusercontent.com/assets/55841/10323102/43a66d24-6c81-11e5-9551-cd4986db0104.png)

Right now it has two tips, if you can think of more I'll add them:
* `Hit the <kbd>?</kbd> key for all keyboard awesomeness.`
* `You can reply to comments below the notifications.`