### PR TITLE
Migrate to Cedar 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "nib": "~1.0.1",
     "lineman-bower": "0.0.3",
     "grunt-manifest": "git+https://github.com/gunta/grunt-manifest.git#6b830e31"
+  },
+  "scripts": {
+    "postinstall": "lineman build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "company": "GitHub"
   },
   "engines": {
-    "node": "~>0.10.5",
-    "npm": "~>1.3.11"
+    "node": "0.10.x",
+    "npm": "1.3.x"
   },
   "dependencies": {
     "express": "~3.4.4"


### PR DESCRIPTION
Heroku is deprecating the cedar-10 stack, and the [lineman buildpack](https://github.com/linemanjs/heroku-buildpack-lineman) is deprecated and does not run on cedar-14. This switches to the standard node buildpack, and [migrates to cedar-14](https://devcenter.heroku.com/articles/cedar-14-migration). I have tested this on [staging](https://gh-notifications-staging.herokuapp.com/).

- [x] `heroku config:set BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-nodejs`
- [x] `heroku stack:set cedar-14`
- [x] `git push heroku cedar-14:master`
